### PR TITLE
Binaries excluded - Arduino simulation plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /Debug
 /Binaries
 /Plugins/**/Intermediate/*
+/Plugins/**/Binaries/*
 /.vscode
 /.vs
 .vsconfig

--- a/Plugins/LEDBlinkTest/Binaries/Win64/UnrealEditor.modules
+++ b/Plugins/LEDBlinkTest/Binaries/Win64/UnrealEditor.modules
@@ -1,7 +1,0 @@
-{
-	"BuildId": "33043543",
-	"Modules": 
-	{
-		"LEDBlinkTest": "UnrealEditor-LEDBlinkTest.dll"
-	}
-}


### PR DESCRIPTION
- Fixes gitignore to remove all /Binaries content from plugin
- Adds the simulation map LEDBlinkTest1 under Content/Maps
- Adds simulation plugin "LEDBlinkTest1" including static library and interfacing classes
- Adds support BP classes under Content/ArduinoSimulator